### PR TITLE
myticket 수정

### DIFF
--- a/css/myticket/myticket_empty.css
+++ b/css/myticket/myticket_empty.css
@@ -126,6 +126,56 @@ main {
   justify-content: space-around;
   background-color: #000;
 }
+.tabcontent .ticket {
+  width: 100%;
+}
+.tabcontent .top {
+  position: relative;
+}
+.tabcontent .top img {
+  width: 280px;
+  height: 100%;
+}
+.tabcontent .qrContainer {
+  position: absolute;
+  top: 28%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+}
+.tabcontent .qrContainer img {
+  width: 100px;
+  height: 100px;
+}
+.tabcontent .bottom {
+  position: relative;
+}
+.tabcontent .bottom::before {
+  content: "";
+  position: absolute;
+  top: -2px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 224px;
+  border-top: 4px dashed #fff;
+}
+.tabcontent .bottom img {
+  width: 280px;
+  height: 280px;
+}
+.tabcontent .infoContainer {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+}
+.tabcontent .infoContainer p {
+  color: #000;
+  margin: 0;
+  text-align: left;
+}
+.tabcontent .infoContainer .infoB {
+  font-weight: 800;
+}
 .tablink {
   background-color: #000;
   color: #fff;
@@ -173,7 +223,7 @@ footer .contents {
 }
 footer .contents p {
   text-align: center;
-  font-size: 9px;
+  font-size: 14px;
   line-height: 24px;
   /* 266.667% */
   margin: 0;
@@ -185,7 +235,7 @@ footer .contents .icoGroup {
 }
 footer span {
   text-align: center;
-  font-size: 7px;
+  font-size: 14px;
   line-height: 24px;
 }
 .tapContainer {

--- a/html/myticket.html
+++ b/html/myticket.html
@@ -48,9 +48,30 @@
         <button class="tablink active" onclick="openTab(event, 'availableTickets')">사용 가능한 티켓</button>
         <button class="tablink" onclick="openTab(event, 'unavailableTickets')">사용 불가능한 티켓</button>
       </div>
-      <div id="availableTickets" class="tabcontent">
-        <p>사용 가능한 티켓이 없습니다.</p>
-        <a href="/waterbomb_project/html/ticket_selection.html"><button class="buyTickets">Buy Tickets</button></a>
+      <div id="availableTickets" class="tabcontent" style="display: block;">
+        <div class="ticket">
+          <div class="top">
+            <img src="/waterbomb_project/image/myticket/ticketTop.svg" alt="티켓 상단이미지" class="ticketTop">
+          </div>
+          <div class="qrContainer">
+            <img src="/waterbomb_project/image/myticket/qrcode.png" alt="QR코드 이미지" class="ticketTop">
+          </div>
+        </div>
+        <div class="bottom">
+          <img src="/waterbomb_project/image/myticket/ticketBottom.svg" alt="티켓 하단이미지">
+          <div class="infoContainer">
+            <p class="infoG">예매번호</p>
+            <p class="infoB">2024000012987653</p>
+            <p class="infoG">장소</p>
+            <p class="infoB">SEOUL</p>
+            <p class="infoG">날짜</p>
+            <p class="infoB">2024.7.5</p>
+            <p class="infoG">시간</p>
+            <p class="infoB">14:00</p>
+            <p class="infoG">좌석등급</p>
+            <p class="infoB">vvip</p>
+          </div>
+        </div>
       </div>
       <div id="unavailableTickets" class="tabcontent" style="display:none">
         <p>사용한 티켓이 없습니다.</p>

--- a/js/myticket_empty.js
+++ b/js/myticket_empty.js
@@ -31,21 +31,29 @@ document.addEventListener("DOMContentLoaded", () => {
     }
   });
 });
-// 사용 가능 티켓 탭구조
 function openTab(evt, tabName) {
-  let i, tabcontent, tablinks;
-  tabcontent = document.querySelectorAll(".tabcontent");
+  var i, tabcontent, tablinks;
+  // 모든 탭 콘텐츠를 숨깁니다.
+  tabcontent = document.getElementsByClassName("tabcontent");
   for (i = 0; i < tabcontent.length; i++) {
     tabcontent[i].style.display = "none";
   }
-  tablinks = document.querySelectorAll(".tablink");
+  // 모든 탭 링크에서 "active" 클래스를 제거합니다.
+  tablinks = document.getElementsByClassName("tablink");
   for (i = 0; i < tablinks.length; i++) {
-    tablinks[i].classList.remove("active");
+    tablinks[i].className = tablinks[i].className.replace(" active", "");
   }
+  // 클릭된 탭 콘텐츠를 표시합니다.
   document.getElementById(tabName).style.display = "block";
-  evt.currentTarget.classList.add("active");
+  // 클릭된 탭 링크에 "active" 클래스를 추가합니다.
+  evt.currentTarget.className += " active";
 }
-// 기본으로 첫 번째 탭 열기
+// 기본으로 첫 번째 탭을 표시합니다.
 document.addEventListener("DOMContentLoaded", function () {
-  document.querySelector(".tablink").click();
+  // 사용 가능한 티켓 탭을 기본 활성화 상태로 설정
+  document.getElementById("availableTickets").style.display = "block";
+  var defaultTab = document.querySelector(".tablink");
+  if (defaultTab) {
+    defaultTab.className += " active";
+  }
 });


### PR DESCRIPTION
### 🔥 작업 내용
<!-- '어떻게'보다는 '무엇을', '왜' 작업했는지를 좀 더 자세히 기술해 주세요 -->
사용 가능한 티켓 클릭했을 시, 티켓 모양 안에 상단에는 qr코드, 하단에는 예매정보가 나오게 작업함
사용 불가능한 티켓을 클릭했을 시, 탭 안에 티켓에 대한 안내가 나오게 작업함

### 💦 이슈
<!-- 작업중 발생했지만 해결한 이슈에 대해 기술해주세요. 미해결 이슈는 Issues 탭에 등록! -->
기존 작업 내용에서는 사용 불가능한 티켓에 대한 안내가 사용 불가능한 티켓탭 div 바깥에 있었지만
해결함. 
#unavailableTickets를 div.container 안에 넣어, #availableTickets와 같은 레벨에 위치하도록 조정함.

### 🙄 같이 고민해요
<!-- 이번 PR 작업물 작업 중 잘 구현되지 않았던 점이 있었나요? 털어놓고 함께 더 나은 방안을 생각해 봅시다 -->
400px이하로 크기가 줄어들면 absolut 해놓은 qr코드 위치가 무너짐.
### 💌 추가 코멘트
<!-- 코드 리뷰어에게 추가적으로 하고 싶은 말을 적어 주세요. 없으면 '없음' 기재 -->
바뀐 헤더 부분과 Buy Tickets 호버 효과는 아직 수정하지 못함. 


